### PR TITLE
Remove docker volumes

### DIFF
--- a/run-docker
+++ b/run-docker
@@ -82,8 +82,8 @@ else
     eval $ANNOTATE_IN
     docker start -a $CONTAINER
     docker cp $CONTAINER:/home/builder/bench.out $OUTFILE
-    docker rm $CONTAINER
     eval $ANNOTATE_OUT
+    docker rm $CONTAINER
     rm $CIDFILE
 fi
 

--- a/run-docker
+++ b/run-docker
@@ -4,8 +4,6 @@ set -e
 
 LOCAL_FILE=`realpath $1`
 
-TARGET_FILE="$BENCH_ROOT/$1"
-
 COMPILER=$2
 OPTIM_FLAG=$3
 VERSION_FLAG=$4
@@ -46,13 +44,11 @@ fi
 
 LOCK=$LOCAL_FILE.lock
 lockfile $LOCK
-INFILE=$TARGET_FILE.cpp
+INFILE=$LOCAL_FILE.cpp
 OUTFILE=$LOCAL_FILE.out
-TARG_OUTFILE=$TARGET_FILE.out
 CIDFILE=$LOCAL_FILE.cid
-LOC_PERFFILE=$LOCAL_FILE.perf
-PERFFILE=$TARGET_FILE.perf
-FUNCFILE=$TARGET_FILE.func
+PERFFILE=$LOCAL_FILE.perf
+FUNCFILE=$LOCAL_FILE.func
 if [ $CLEAN_CACHE = true ] && [ -f $OUTFILE ]; then
     rm $OUTFILE
     rm -f $LOC_PERFFILE
@@ -68,18 +64,26 @@ else
     fi
 
     if [ $RECORD_PERF = true ]; then
-        touch $LOC_PERFFILE
-        chmod 666 $LOC_PERFFILE
-        ANNOTATE="--security-opt seccomp=seccomp.json -v $PERFFILE:/home/builder/bench.perf -v $FUNCFILE:/home/builder/bench.func"
+        touch $PERFFILE
+        chmod 666 $PERFFILE
+        ANNOTATE="--security-opt seccomp=seccomp.json"
         ANNOTATE_CMD=" && ./annotate"
         ANNOTATE_RECORD="perf record -g"
+	ANNOTATE_IN="docker cp $FUNCFILE \$CONTAINER:/home/builder/bench.func"
+	ANNOTATE_OUT="docker cp \$CONTAINER:/home/builder/bench.perf $PERFFILE"
     fi
     if [[ $LIB_VERSION == llvm ]] && [[ $COMPILER == clang* ]]; then
         BUILD_COMMAND=build-libcxx
     else
         BUILD_COMMAND=build
     fi
-    docker run --rm $ANNOTATE -v $INFILE:/home/builder/bench-file.cpp $MEMORY_LIMITS --cidfile=$CIDFILE -v $TARG_OUTFILE:/home/builder/bench.out -t fredtingaud/quick-bench:$COMPILER /bin/bash -c "./$BUILD_COMMAND $OPTIM $VERSION && $ANNOTATE_RECORD ./run $ANNOTATE_CMD"
+    CONTAINER=$(docker create $ANNOTATE $MEMORY_LIMITS --cidfile=$CIDFILE -t fredtingaud/quick-bench:$COMPILER /bin/bash -c "./$BUILD_COMMAND $OPTIM $VERSION && $ANNOTATE_RECORD ./run $ANNOTATE_CMD")
+    docker cp $INFILE $CONTAINER:/home/builder/bench-file.cpp
+    eval $ANNOTATE_IN
+    docker start -a $CONTAINER
+    docker cp $CONTAINER:/home/builder/bench.out $OUTFILE
+    docker rm $CONTAINER
+    eval $ANNOTATE_OUT
     rm $CIDFILE
 fi
 

--- a/run-docker-builder
+++ b/run-docker-builder
@@ -101,6 +101,7 @@ else
     docker cp $CONTAINER:/home/builder/bench.inc $INCLUDES
     eval $PP_OUT
     eval $ASM_OUT
+    docker rm $CONTAINER
     rm $CIDFILE
 fi
 

--- a/run-docker-builder
+++ b/run-docker-builder
@@ -4,8 +4,6 @@ set -e
 
 LOCAL_FILE=`realpath $1`
 
-TARGET_FILE="$BENCH_ROOT/$1"
-
 COMPILER=$2
 OPTIM_FLAG=$3
 VERSION_FLAG=$4
@@ -42,15 +40,11 @@ fi
 
 LOCK=$LOCAL_FILE.lock
 lockfile $LOCK
-INFILE=$TARGET_FILE.cpp
+INFILE=$LOCAL_FILE.cpp
 OUTFILE=$LOCAL_FILE.build
-TARG_OUTFILE=$TARGET_FILE.build
 INCLUDES=$LOCAL_FILE.inc
-TARG_INCLUDES=$TARGET_FILE.inc
 ASM=$LOCAL_FILE.s
-TARG_ASM=$TARGET_FILE.s
 PP=$LOCAL_FILE.i
-TARG_PP=$TARGET_FILE.i
 CIDFILE=$LOCAL_FILE.cid
 if [ $CLEAN_CACHE = true ] && [ -f $OUTFILE ]; then
     rm $OUTFILE
@@ -81,12 +75,12 @@ else
     if [ $RECORD_PP = true ]; then
         touch $PP
         chmod 666 $PP
-        PREBUILD_V="-v $TARG_PP:/home/builder/bench.i"
+	PP_OUT="docker cp \$CONTAINER:/home/builder/bench.i $PP"
     fi
     if [ "$RECORD_ASM" != "none" ]; then
         touch $ASM
         chmod 666 $ASM
-        PREBUILD_V="$PREBUILD_V -v $TARG_ASM:/home/builder/bench.s"
+	ASM_OUT="docker cp \$CONTAINER:/home/builder/bench.s $ASM"
     fi
 
     PREBUILD_PARAMS="$RECORD_PP $RECORD_ASM"
@@ -96,13 +90,17 @@ else
     if [ -z ${BB_MAX_ITERATION+x} ]; then
         ENV_PARAMS="$ENV_PARAMS -e BB_MAX=$BB_MAX_ITERATION"
     fi
-    docker run --rm $ANNOTATE -v $INFILE:/home/builder/$FILE_NAME $MEMORY_LIMITS \
+    CONTAINER=$(docker create $ANNOTATE $MEMORY_LIMITS \
                               --cidfile=$CIDFILE \
-                              -v $TARG_OUTFILE:/home/builder/bench.out \
-                              -v $TARG_INCLUDES:/home/builder/bench.inc \
                               $ENV_PARAMS \
-                              $PREBUILD_V \
                fredtingaud/quick-bench:$COMPILER /bin/bash -c "./$PREBUILD_COMMAND $FILE_NAME $PREBUILD_PARAMS $OPTIM $VERSION && ./$BUILD_COMMAND $FILE_NAME $OPTIM $VERSION"
+    )
+    docker cp $INFILE $CONTAINER:/home/builder/$FILE_NAME
+    docker start -a $CONTAINER
+    docker cp $CONTAINER:/home/builder/bench.out $OUTFILE
+    docker cp $CONTAINER:/home/builder/bench.inc $INCLUDES
+    eval $PP_OUT
+    eval $ASM_OUT
     rm $CIDFILE
 fi
 

--- a/system-test/build.js
+++ b/system-test/build.js
@@ -28,7 +28,6 @@ describe('run build-bench', function () {
             withPP: true
         };
         expect(version).to.be.ok;
-        process.env.BENCH_ROOT = process.cwd();
         const done = await libbuild.execute('system-test/build/test', request, 3, true);
         // Time results are rows of 7 elements separated by tabs
         expect(done.res.split('\n')).to.have.lengthOf.above(1);

--- a/system-test/quick.js
+++ b/system-test/quick.js
@@ -29,7 +29,6 @@ describe('run docker with version', function () {
             force: "true"
         };
         expect(version).to.be.ok;
-        process.env.BENCH_ROOT = process.cwd();
         const done = await libquick.execute('system-test/quick/test', request);
         const parsed = JSON.parse(done.res);
         expect(parsed.benchmarks).to.have.length(2);


### PR DESCRIPTION
There are two issues with docker volumes when already running inside docker (docker-in-docker):
1. it doesn't really work on Windows - my main concern;
2. it requires passing in BENCH_ROOT - not particularly nice too.

Copying files in and out of container instead of mounting volumes addresses both of them.