### PR TITLE
Add Support for Configurable ASM Formats In Annotated Perf Recordings

### DIFF
--- a/app-quick.js
+++ b/app-quick.js
@@ -26,7 +26,7 @@ app.get('/quick-env', upload.array(), function (req, res) {
 
 app.post('/quick', upload.array(), function (req, res) {
     Promise.resolve(libquick.benchmark(req.body, req.headers))
-        .then((done) => res.json(libquick.makeGraphResult(done.res ? JSON.parse(done.res) : null, done.stdout, done.id, done.annotation)))
+        .then((done) => res.json(libquick.makeGraphResult(done.res ? JSON.parse(done.res) : null, done.stdout, done.id, done.annotation, done.disassemblyOption)))
         .catch((err) => res.json({ message: err }));
 });
 

--- a/run-docker
+++ b/run-docker
@@ -48,7 +48,7 @@ INFILE=$LOCAL_FILE.cpp
 OUTFILE=$LOCAL_FILE.out
 CIDFILE=$LOCAL_FILE.cid
 PERFFILE=$LOCAL_FILE.perf
-FUNCFILE=$TARGET_FILE.func
+FUNCFILE=$LOCAL_FILE.func
 CONTAINERFILE=$LOCAL_FILE.cont
 
 if [ ${OPTIONAL_RECORD_ASM_FORMAT} == "no" ]; then
@@ -62,7 +62,7 @@ if [ $CLEAN_CACHE = true ] && [ -f $OUTFILE ]; then
     rm $OUTFILE
     rm -f $LOC_PERFFILE
 fi
-if [ -f $OUTFILE ] && ([ ${RECORD_PERF} = false ] || [ -f $LOC_PERFFILE ]); then
+if [ -f $OUTFILE ] && ([ ${RECORD_PERF} = false ]); then
     >&2 echo "Showing cached results"
 else
     touch $OUTFILE
@@ -76,7 +76,6 @@ else
         touch $PERFFILE
         chmod 666 $PERFFILE
         ANNOTATE="--security-opt seccomp=seccomp.json"
-        ANNOTATE_CMD=" && ./annotate"
         ANNOTATE_CMD=" && ASM_FORMAT=${ASM_FORMAT} ./annotate"
         ANNOTATE_RECORD="perf record -g"
         ANNOTATE_IN="docker cp $FUNCFILE \$CONTAINER:/home/builder/bench.func"

--- a/run-docker
+++ b/run-docker
@@ -7,7 +7,7 @@ LOCAL_FILE=`realpath $1`
 COMPILER=$2
 OPTIM_FLAG=$3
 VERSION_FLAG=$4
-RECORD_PERF=$5
+OPTIONAL_RECORD_ASM_FORMAT=$5
 CLEAN_CACHE=$6
 LIB_VERSION=$7
 
@@ -48,13 +48,21 @@ INFILE=$LOCAL_FILE.cpp
 OUTFILE=$LOCAL_FILE.out
 CIDFILE=$LOCAL_FILE.cid
 PERFFILE=$LOCAL_FILE.perf
-FUNCFILE=$LOCAL_FILE.func
+FUNCFILE=$TARGET_FILE.func
 CONTAINERFILE=$LOCAL_FILE.cont
+
+if [ ${OPTIONAL_RECORD_ASM_FORMAT} == "no" ]; then
+	RECORD_PERF="no"
+else
+	RECORD_PERF="yes"
+fi
+ASM_FORMAT=${OPTIONAL_RECORD_ASM_FORMAT}
+
 if [ $CLEAN_CACHE = true ] && [ -f $OUTFILE ]; then
     rm $OUTFILE
     rm -f $LOC_PERFFILE
 fi
-if [ -f $OUTFILE ] && ([ $RECORD_PERF = false ] || [ -f $LOC_PERFFILE ]); then
+if [ -f $OUTFILE ] && ([ ${RECORD_PERF} = false ] || [ -f $LOC_PERFFILE ]); then
     >&2 echo "Showing cached results"
 else
     touch $OUTFILE
@@ -64,14 +72,15 @@ else
         MEMORY_LIMITS='--memory=500m --cpu-period=100000 --cpu-quota=25000'
     fi
 
-    if [ $RECORD_PERF = true ]; then
+    if [ "${RECORD_PERF}" = "yes" ]; then
         touch $PERFFILE
         chmod 666 $PERFFILE
         ANNOTATE="--security-opt seccomp=seccomp.json"
         ANNOTATE_CMD=" && ./annotate"
+        ANNOTATE_CMD=" && ASM_FORMAT=${ASM_FORMAT} ./annotate"
         ANNOTATE_RECORD="perf record -g"
-	ANNOTATE_IN="docker cp $FUNCFILE \$CONTAINER:/home/builder/bench.func"
-	ANNOTATE_OUT="docker cp \$CONTAINER:/home/builder/bench.perf $PERFFILE"
+        ANNOTATE_IN="docker cp $FUNCFILE \$CONTAINER:/home/builder/bench.func"
+        ANNOTATE_OUT="docker cp \$CONTAINER:/home/builder/bench.perf $PERFFILE"
     fi
     if [[ $LIB_VERSION == llvm ]] && [[ $COMPILER == clang* ]]; then
         BUILD_COMMAND=build-libcxx


### PR DESCRIPTION
With these PRs, quick bench will support annotated perf recordings in user-customizable syntax formats. There is a bonus commit here that adds a `--notest` option to the `build-container.py` script for those of us who do not want to wait for the testing to complete! 

I know that there is still the issue of how to handle incompatible versions. But, I wanted to get this in ASAP just so you knew that I was still interested in contributing! 

Please let me know how you think it's best to handle the versioning problem and I'll be happy to adjust accordingly!

Thanks, as always, for all the work that you are doing on this great tool!
