### PR TITLE
Allow setting limit on bodyParser.json

### DIFF
--- a/app-quick.js
+++ b/app-quick.js
@@ -11,11 +11,11 @@ var libquick = require('./src/libquick');
 var docker = require('./src/docker');
 
 const PORT = process.env.QB_PORT | 4000;
+const POST_LIMIT = process.env.QB_POST_LIMIT | (100 * 1024);
 
 var upload = multer();
 
-
-app.use(bodyParser.json());
+app.use(bodyParser.json({limit: POST_LIMIT}));
 app.use(cors());
 
 libquick.updateAvailableContainersList();


### PR DESCRIPTION
The limit option of bodyParser.json() allow to define programmatically the maximum size of the request body, by default is set to 100kb but in some cases large tests might require well more.

Add the ability to tune the parameter setting the default to the Express default value of 100kb to do not alter the current behaviour.